### PR TITLE
Remove placeholder homepage component

### DIFF
--- a/app/(root)/layout.tsx
+++ b/app/(root)/layout.tsx
@@ -1,0 +1,14 @@
+import { Header } from "@/components/Header"
+
+const layout = ({ children }: { children : React.ReactNode }) => {
+  return (
+        <main className="min-h-screen text-gray-400">
+            <Header/>
+            <div className="container py-10">
+                {children}
+            </div>
+        </main>
+    )
+}
+
+export default layout

--- a/app/(root)/page.tsx
+++ b/app/(root)/page.tsx
@@ -4,8 +4,8 @@ import React from 'react'
 
 const Home = () => {
   return (
-    <div className='flex justify-center items-center h-screen'>
-      <Button>Click Me</Button>
+    <div className='flex min-h-screen home-wrapper'>
+      <Button>Home</Button>
     </div>
   )
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,19 @@
+import Image from "next/image"
+import Link from "next/link"
+import NavItems from "./NavItems"
+
+export const Header = () => {
+  return (
+    <header className="sticky top-0 header">
+        <div className="container header-wrapper">
+            <Link href="/">
+                <Image src="/assets/icons/logo.svg" alt="Quantevo Logo" width={140} height={32} className="h-8 w-auto cursor-pointer" />
+            </Link>
+            <nav className="hidden sm:block">
+                <NavItems />
+            </nav>
+            {/* UserDropDown */}
+        </div>
+    </header>
+  )
+}

--- a/components/NavItems.tsx
+++ b/components/NavItems.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { Nav_Items } from "@/lib/constants"
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import React from "react"
+
+const NavItems = () => {
+  const pathname = usePathname()
+
+  const isActive = (path: string) => {
+    if (path === "/") return pathname === "/"
+    return pathname.startsWith(path)
+  }
+
+  return (
+    <ul className="flex flex-col sm:flex-row p-2 gap-3 sm:gap-10 font-medium">
+      {Nav_Items.map(({ href, label }) => (
+        <li key={href}>
+          <Link
+            href={href}
+            className={`hover:text-yellow-500 transition-colors ${
+              isActive(href) ? "text-gray-100" : ""
+            }`}
+          >
+            {label}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default NavItems

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,5 @@
+export const Nav_Items : { href: string; label: string }[] = [
+    { href: '/', label: 'Dashboard' },
+    { href: '/search', label: 'Search' },
+    { href: '/watchlist', label: 'Watchlist' },
+]


### PR DESCRIPTION
Removes the simple centered placeholder homepage component that rendered a demo button.

Cleans up unused UI scaffolding to avoid duplicate/default route rendering and prepare the app for a new homepage or routing/layout structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a persistent app layout with a sticky header.
  - Added a logo link and a responsive navigation menu (Dashboard, Search, Watchlist) with active state highlighting.

- Style
  - Updated the home page structure to use the new layout with improved spacing and min-height.
  - Renamed the primary button label to “Home.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->